### PR TITLE
se creo la clase GestorDeReservaError

### DIFF
--- a/src/clasesDeError/GestorDeReservaError.ts
+++ b/src/clasesDeError/GestorDeReservaError.ts
@@ -1,0 +1,11 @@
+export default class GestorDeReservaError extends Error {
+
+    constructor(mensaje: string) {
+        super(mensaje);
+        this.name = "GestorDeReservaError"
+        Object.setPrototypeOf(this, GestorDeReservaError.prototype);
+    }
+
+
+
+}


### PR DESCRIPTION
se creó la clase error de Gestor de reserva para manejar excepciones de dicha clase, no se realizaron los métodos correspondientes debido a un cambio en desarrollo.